### PR TITLE
Prepend fitbit_ to sensor entity_ids

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -435,7 +435,7 @@ class FitbitSensor(SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        return "fitbit_" + self._name
 
     @property
     def state(self):


### PR DESCRIPTION
Instead of just having the entity_ids as just the metric title, this prepends it, in order to keep all the entities together.
eg from sensor.resting_heart_rate to sensor.fitbit_resting_heart_rate.

I've added it to this repo as I'm using this repo, but I will now track down the original script and change it in there too.